### PR TITLE
7 feat: add translation attributes

### DIFF
--- a/Sondor.Translations/Sondor.Translations.Tests/Attributes/TranslationDefaultAttributeTests.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Attributes/TranslationDefaultAttributeTests.cs
@@ -1,0 +1,26 @@
+﻿using Sondor.Translations.Attributes;
+
+namespace Sondor.Translations.Tests.Attributes;
+
+/// <summary>
+/// Tests for the <see cref="TranslationDefaultAttribute"/> class.
+/// </summary>
+[TestFixture]
+public class TranslationDefaultAttributeTests
+{
+    /// <summary>
+    /// Ensures that the constructor of <see cref="TranslationDefaultAttribute"/> works as expected.
+    /// </summary>
+    [Test]
+    public void Constructor()
+    {
+        // arrange
+        const string defaultValue = "Default Value";
+
+        // act
+        var attribute = new TranslationDefaultAttribute(defaultValue);
+
+        // assert
+        Assert.That(attribute.DefaultValue, Is.EqualTo(defaultValue));
+    }
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/Attributes/TranslationKeyAttributeTests.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Attributes/TranslationKeyAttributeTests.cs
@@ -1,0 +1,26 @@
+﻿using Sondor.Translations.Attributes;
+
+namespace Sondor.Translations.Tests.Attributes;
+
+/// <summary>
+/// Tests for the <see cref="TranslationKeyAttribute"/> class.
+/// </summary>
+[TestFixture]
+public class TranslationKeyAttributeTests
+{
+    /// <summary>
+    /// Ensures that the constructor of <see cref="TranslationKeyAttribute"/> works as expected.
+    /// </summary>
+    [Test]
+    public void Constructor()
+    {
+        // arrange
+        const string key = "TestKey";
+
+        // act
+        var attribute = new TranslationKeyAttribute(key);
+
+        // assert
+        Assert.That(attribute.Key, Is.EqualTo(key));
+    }
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/Constants/TestTranslationConstants.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Constants/TestTranslationConstants.cs
@@ -1,0 +1,17 @@
+﻿namespace Sondor.Translations.Tests.Constants;
+
+/// <summary>
+/// Collection of test translations.
+/// </summary>
+internal static class TestTranslationConstants
+{
+    /// <summary>
+    /// The translation key for the test translation key.
+    /// </summary>
+    internal const string TestTranslationKey = "translation-key";
+
+    /// <summary>
+    /// The test translation default message.
+    /// </summary>
+    internal const string TestTranslationDefault = "Default translation message.";
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/Exceptions/UnsupportedTranslationDefaultExceptionTests.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Exceptions/UnsupportedTranslationDefaultExceptionTests.cs
@@ -1,0 +1,33 @@
+﻿using Sondor.Translations.Constants;
+using Sondor.Translations.Exceptions;
+
+namespace Sondor.Translations.Tests.Exceptions;
+
+/// <summary>
+/// Tests for the <see cref="UnsupportedTranslationDefaultException"/> class.
+/// </summary>
+[TestFixture]
+public class UnsupportedTranslationDefaultExceptionTests
+{
+    /// <summary>
+    /// Ensures that the constructor of <see cref="UnsupportedTranslationDefaultException"/> works as expected.
+    /// </summary>
+    [Test]
+    public void Constructor()
+    {
+        // arrange
+        var type = typeof(string);
+        var expectedMessage = string.Format(ExceptionConstants.UnsupportedTranslationDefaultType, type.Name);
+
+        // act
+        var exception = new UnsupportedTranslationDefaultException(type);
+
+        // assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            Assert.That(exception, Is.InstanceOf<UnsupportedTranslationDefaultException>());
+        }
+    }
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/Exceptions/UnsupportedTranslationKeyExceptionTests.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Exceptions/UnsupportedTranslationKeyExceptionTests.cs
@@ -1,0 +1,33 @@
+﻿using Sondor.Translations.Constants;
+using Sondor.Translations.Exceptions;
+
+namespace Sondor.Translations.Tests.Exceptions;
+
+/// <summary>
+/// Tests for the <see cref="UnsupportedTranslationKeyException"/> class.
+/// </summary>
+[TestFixture]
+public class UnsupportedTranslationKeyExceptionTests
+{
+    /// <summary>
+    /// Ensures that the constructor of <see cref="UnsupportedTranslationKeyException"/> works as expected.
+    /// </summary>
+    [Test]
+    public void Constructor()
+    {
+        // arrange
+        var type = typeof(string);
+        var expectedMessage = string.Format(ExceptionConstants.UnsupportedTranslationKeyType, type.Name);
+
+        // act
+        var exception = new UnsupportedTranslationKeyException(type);
+
+        // assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(exception, Is.Not.Null);
+            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            Assert.That(exception, Is.InstanceOf<UnsupportedTranslationKeyException>());
+        }
+    }
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/Extensions/EnumExtensionsTests.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/Extensions/EnumExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿using Sondor.Translations.Extensions;
+using Sondor.Translations.Tests.Constants;
+
+namespace Sondor.Translations.Tests.Extensions;
+
+/// <summary>
+/// Tests for the <see cref="EnumExtensions"/> class.
+/// </summary>
+[TestFixture]
+public class EnumExtensionsTests
+{
+    /// <summary>
+    /// Ensures that the <see cref="EnumExtensions.GetTranslationKey{TEnum}"/> method works as expected.
+    /// </summary>
+    [Test]
+    public void GetTranslationKey()
+    {
+        // arrange
+        const TestTranslations translation = TestTranslations.Test;
+        const string expected = TestTranslationConstants.TestTranslationKey;
+
+        // act
+        var key = translation.GetTranslationKey();
+
+        // assert
+        Assert.That(key, Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// Ensures that the <see cref="EnumExtensions.GetTranslationDefault{TEnum}"/> method works as expected.
+    /// </summary>
+    [Test]
+    public void GetTranslationDefault()
+    {
+        // arrange
+        const TestTranslations translation = TestTranslations.Test;
+        const string expected = TestTranslationConstants.TestTranslationDefault;
+
+        // act
+        var key = translation.GetTranslationDefault();
+
+        // assert
+        Assert.That(key, Is.EqualTo(expected));
+    }
+}

--- a/Sondor.Translations/Sondor.Translations.Tests/TestTranslations.cs
+++ b/Sondor.Translations/Sondor.Translations.Tests/TestTranslations.cs
@@ -1,0 +1,17 @@
+﻿using Sondor.Translations.Attributes;
+using Sondor.Translations.Tests.Constants;
+
+namespace Sondor.Translations.Tests;
+
+/// <summary>
+/// Collection of test translations.
+/// </summary>
+internal enum TestTranslations
+{
+    /// <summary>
+    /// The test translation.
+    /// </summary>
+    [TranslationKey(TestTranslationConstants.TestTranslationKey)]
+    [TranslationDefault(TestTranslationConstants.TestTranslationDefault)]
+    Test = 1
+}

--- a/Sondor.Translations/Sondor.Translations/Attributes/TranslationDefaultAttribute.cs
+++ b/Sondor.Translations/Sondor.Translations/Attributes/TranslationDefaultAttribute.cs
@@ -1,0 +1,18 @@
+﻿namespace Sondor.Translations.Attributes;
+
+/// <summary>
+/// Translation default attribute.
+/// </summary>
+/// <remarks>
+/// Creates a new instance of <see cref="TranslationDefaultAttribute"/>.
+/// </remarks>
+/// <param name="defaultValue">The default value/</param>
+[AttributeUsage(AttributeTargets.Field)]
+public class TranslationDefaultAttribute(string defaultValue) :
+    Attribute
+{
+    /// <summary>
+    /// The default value.
+    /// </summary>
+    public string DefaultValue { get; } = defaultValue;
+}

--- a/Sondor.Translations/Sondor.Translations/Attributes/TranslationKeyAttribute.cs
+++ b/Sondor.Translations/Sondor.Translations/Attributes/TranslationKeyAttribute.cs
@@ -1,0 +1,18 @@
+﻿namespace Sondor.Translations.Attributes;
+
+/// <summary>
+/// Translation key attribute.
+/// </summary>
+/// <remarks>
+/// Create a new instance of <see cref="TranslationKeyAttribute"/>.
+/// </remarks>
+/// <param name="key">The translation key.</param>
+[AttributeUsage(AttributeTargets.Field)]
+public class TranslationKeyAttribute(string key) :
+    Attribute
+{
+    /// <summary>
+    /// The translation key.
+    /// </summary>
+    public string Key { get; } = key;
+}

--- a/Sondor.Translations/Sondor.Translations/Constants/ExceptionConstants.cs
+++ b/Sondor.Translations/Sondor.Translations/Constants/ExceptionConstants.cs
@@ -58,4 +58,16 @@ internal class ExceptionConstants
     /// </summary>
     internal const string NoTranslationCulturesErrorFormat =
         "Unfortunately, the translation was loaded successful but contains no translations for any cultures. File: '{0}'.";
+
+    /// <summary>
+    /// The unsupported translation key type error message format.
+    /// </summary>
+    internal const string UnsupportedTranslationKeyType =
+        "The type '{0}' is not supported as a translation key. Please use an enum with the 'TranslationKeyAttribut' applied.";
+
+    /// <summary>
+    /// The unsupported translation default type error message format.
+    /// </summary>
+    internal const string UnsupportedTranslationDefaultType =
+        "The type '{0}' is not supported as a translation default. Please use an enum with the 'TranslationDefaultAttribute' applied.";
 }

--- a/Sondor.Translations/Sondor.Translations/Exceptions/UnsupportedTranslationDefaultException.cs
+++ b/Sondor.Translations/Sondor.Translations/Exceptions/UnsupportedTranslationDefaultException.cs
@@ -1,0 +1,14 @@
+﻿using Sondor.Errors.Exceptions;
+using Sondor.Translations.Constants;
+
+namespace Sondor.Translations.Exceptions;
+
+/// <summary>
+/// Unsupported translation default exception.
+/// </summary>
+/// <remarks>
+/// Creates a new instance of <see cref="UnsupportedTranslationDefaultException"/>.
+/// </remarks>
+/// <param name="type">The unsupported type.</param>
+public class UnsupportedTranslationDefaultException(Type type) :
+    UnsupportedException(string.Format(ExceptionConstants.UnsupportedTranslationDefaultType, type.Name));

--- a/Sondor.Translations/Sondor.Translations/Exceptions/UnsupportedTranslationKeyException.cs
+++ b/Sondor.Translations/Sondor.Translations/Exceptions/UnsupportedTranslationKeyException.cs
@@ -1,0 +1,14 @@
+﻿using Sondor.Errors.Exceptions;
+using Sondor.Translations.Constants;
+
+namespace Sondor.Translations.Exceptions;
+
+/// <summary>
+/// Unsupported translation key exception.
+/// </summary>
+/// <remarks>
+/// Creates a new instance of <see cref="UnsupportedTranslationKeyException"/>.
+/// </remarks>
+/// <param name="type">The unsupported type.</param>
+public class UnsupportedTranslationKeyException(Type type) :
+    UnsupportedException(string.Format(ExceptionConstants.UnsupportedTranslationKeyType, type.Name));

--- a/Sondor.Translations/Sondor.Translations/Extensions/EnumExtensions.cs
+++ b/Sondor.Translations/Sondor.Translations/Extensions/EnumExtensions.cs
@@ -1,0 +1,50 @@
+﻿using Sondor.Translations.Attributes;
+using Sondor.Translations.Exceptions;
+
+namespace Sondor.Translations.Extensions;
+
+/// <summary>
+/// Collection of extension methods for enums.
+/// </summary>
+public static class EnumExtensions
+{
+    /// <summary>
+    /// Gets the translation key for the specified enum instance.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="instance">The instance.</param>
+    /// <returns>Returns the translation key.</returns>
+    /// <exception cref="UnsupportedTranslationKeyException">This exception is thrown when provided <paramref name="instance"/> does not implement <see cref="TranslationKeyAttribute"/>.</exception>
+    public static string GetTranslationKey<TEnum>(this TEnum instance)
+        where TEnum : Enum
+    {
+        var type = instance.GetType();
+        var memberInfo = type.GetMember(instance.ToString());
+
+        var attributes = memberInfo[0].GetCustomAttributes(typeof(TranslationKeyAttribute), false);
+
+        return attributes.Length > 0 ?
+            ((TranslationKeyAttribute)attributes[0]).Key :
+            throw new UnsupportedTranslationKeyException(type);
+    }
+
+    /// <summary>
+    /// Gets the translation default for the specified enum instance.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="instance">The instance.</param>
+    /// <returns>Returns the translation key.</returns>
+    /// <exception cref="UnsupportedTranslationKeyException">This exception is thrown when provided <paramref name="instance"/> does not implement <see cref="TranslationKeyAttribute"/>.</exception>
+    public static string GetTranslationDefault<TEnum>(this TEnum instance)
+        where TEnum : Enum
+    {
+        var type = instance.GetType();
+        var memberInfo = type.GetMember(instance.ToString());
+
+        var attributes = memberInfo[0].GetCustomAttributes(typeof(TranslationDefaultAttribute), false);
+
+        return attributes.Length > 0 ?
+            ((TranslationDefaultAttribute)attributes[0]).DefaultValue :
+            throw new UnsupportedTranslationDefaultException(type);
+    }
+}

--- a/Sondor.Translations/Sondor.Translations/Sondor.Translations.csproj
+++ b/Sondor.Translations/Sondor.Translations/Sondor.Translations.csproj
@@ -47,17 +47,17 @@ offering easy to use solutions for static and dynamic translations.</Description
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Sondor.Errors" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Sondor.Errors" Version="1.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageReference Include="Sondor.Options" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Creating attributes to define the translation key and default translation value by attribute will simplify the configuration process and provide a maintainable solution for an ever-growing translation dictionary.

1. Create translation key attribute
2. Create a translation default value attribute.